### PR TITLE
goreleaser: Commit formula to juliaogris/tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,5 +14,3 @@ brews:
     description: "orderer is a CLI for importing orders into shopify."
     license: "Apache-2.0"
 
-    skip_upload: true
-


### PR DESCRIPTION
Commit formula to juliaogris/tap by removing: `skip-upload: true`.