### PR TITLE
brew: Tidy up brew formula publication

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 brews:
   - tap:
       owner: juliaogris
-      name: tap
+      name: homebrew-tap
       branch: master
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Orderer
 
-`orderer` is a CLI tool for importing orders into shopify.
+`orderer` is a CLI for importing orders into shopify.
 
 ## Usage
 
-Download executable from [releases](https://github.com/juliaogris/orderer/releases)
-or install with go
+Install `orderer` with
 
-	go install github.com/juliaogris/orderer@latest
+	brew tap juliaogris/tap
+	brew install orderer
 
-Try it with:
+Alternatively you can download the executable directly from [releases](https://github.com/juliaogris/orderer/releases) or install with `go install github.com/juliaogris/orderer@latest`
+
+After installation try
 
 	orderer --version
 	orderer --store julias-delights --token ${SHOPIFY_TOKEN} --input testdata/order1.json


### PR DESCRIPTION
Update brew formula repo in goreleaser config as homebrew automatically
adds a `homebrew-` prefix to the formula repo.
Add `brew install orderer` instruction to README.