### PR TITLE
cli: Implement crud, merge and list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Alternatively you can download the executable directly from [releases](https://g
 After installation try
 
 	orderer --version
-	orderer --store julias-delights --token ${SHOPIFY_TOKEN} --input testdata/order1.json
 
-Request `${SHOPIFY_TOKEN}` from Julia or use your own store, admin token and product ID.
+	export SHOPIFY_STORE=julias-delights
+	export SHOPIFY_TOKEN=shpat_6a....5470  # ask Julia for token or setup your own store and admin token.
+	
+	orderer create testdata/order.json
+	orderer list testdata/order.json
 
 [releases]: https://github.com/juliaogris/orderer/releases
 

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,1 +1,5 @@
 manage-git = false
+env = {
+  GOBIN: "${HERMIT_ENV}/out/bin",
+  PATH: "${GOBIN}:${PATH}",
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,19 +19,64 @@ var (
 	date    = "now"
 
 	description = `
-orderer imports orders into Shopify store
+orderer creates, updates or deletes orders in Shopify store.
+
+It can be used as an importing tool.
+The order is provided in JSON file and its "name" attribute serves as
+identifier.
 `
-	cli struct {
-		Config
-		Version kong.VersionFlag `help:"Show version." env:"-"`
-	}
 )
 
+type CLI struct {
+	Get     GetCmd           `cmd:"" help:"Get order by order ID"`
+	List    ListCmd          `cmd:"" help:"List orders with matching name"`
+	Create  CreateCmd        `cmd:"" help:"Create order"`
+	Update  UpdateCmd        `cmd:"" help:"Update order"`
+	Merge   MergeCmd         `cmd:"" help:"Create or update order"`
+	Delete  DeleteCmd        `cmd:"" help:"Delete order"`
+	Version kong.VersionFlag `help:"Show version." env:"-"`
+}
+
 type Config struct {
-	Store string          `required:"" help:"Shopify store name as found in <name>.myshopify.com URL."`
-	Token string          `required:"" help:"Shopify Admin token."`
-	Order goshopify.Order `required:"" type:"jsonfile" name:"input" short:"i" help:"File containing JSON encoded order to be created"`
-	out   io.Writer
+	Store  string `required:"" help:"Shopify store name as found in <name>.myshopify.com URL."`
+	Token  string `required:"" help:"Shopify Admin token."`
+	out    io.Writer
+	client *goshopify.Client
+}
+
+type GetCmd struct {
+	Config
+	ID int64 `arg:"" required:"" help:"order ID"`
+}
+
+type ListCmd struct {
+	Config
+	Order *goshopify.Order `arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order name to be listed (only name matters)"`
+	Name  string
+}
+
+type CreateCmd struct {
+	Config
+	Order  *goshopify.Order `required:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be created"`
+	Unique bool             `short:"u" help:"assert order name is new"`
+}
+
+type MergeCmd struct {
+	Config
+	Order  *goshopify.Order `required:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be merged (created or updated)"`
+	Unique bool             `short:"u" help:"assert order name is used at most once"`
+}
+
+type UpdateCmd struct {
+	Config
+	Order *goshopify.Order `required:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be updated"`
+}
+
+type DeleteCmd struct {
+	Config
+	Order  *goshopify.Order `required:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be deleted"`
+	Name   string
+	Unique bool `short:"u" help:"assert order name is used at most once"`
 }
 
 var kongOpts = []kong.Option{
@@ -41,24 +87,148 @@ var kongOpts = []kong.Option{
 }
 
 func main() {
-	kctx := kong.Parse(&cli, kongOpts...)
+	kctx := kong.Parse(&CLI{}, kongOpts...)
 	kctx.FatalIfErrorf(kctx.Run())
 }
 
 func (c *Config) AfterApply() error {
 	c.out = os.Stdout
+	opts := []goshopify.Option{
+		goshopify.WithVersion("2019-04"),
+		goshopify.WithRetry(5),
+	}
+	c.client = goshopify.NewClient(goshopify.App{}, c.Store, c.Token, opts...)
+	return nil
+}
+func (c *GetCmd) Run() error {
+	order, err := c.client.Order.Get(c.ID, nil)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(c.out).Encode(order)
+}
+
+func (c *ListCmd) AfterApply() error {
+	if err := c.Config.AfterApply(); err != nil {
+		return err
+	}
+	if c.Name == "" {
+		if c.Order.Name == "" {
+			return errors.New("no order name given")
+		}
+		c.Name = c.Order.Name
+	}
 	return nil
 }
 
-func (c *Config) Run() error {
-	client := goshopify.NewClient(goshopify.App{}, c.Store, c.Token)
+func (c *ListCmd) Run() error {
+	orders, err := c.client.Order.List(listOpts(c.Name))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.out, "number of orders:", len(orders))
+	e := json.NewEncoder(c.out)
+	e.SetIndent("", "  ")
+	for _, o := range orders {
+		fmt.Fprintf(c.out, "id: %d name: %s email: %s\n", o.ID, o.Name, o.Email)
+	}
+	return nil
+}
 
-	order, err := client.Order.Create(c.Order)
+func (c *DeleteCmd) AfterApply() error {
+	if err := c.Config.AfterApply(); err != nil {
+		return err
+	}
+	if c.Name == "" {
+		if c.Order.Name == "" {
+			return errors.New("no order name given")
+		}
+		c.Name = c.Order.Name
+	}
+	return nil
+}
+
+func (c *DeleteCmd) Run() error {
+	orders, err := c.client.Order.List(listOpts(c.Name))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.out, "number of orders to delete:", len(orders))
+	if c.Unique && len(orders) > 1 {
+		return fmt.Errorf("more than one order with name %q", c.Name)
+	}
+	for _, o := range orders {
+		if err := c.client.Delete(fmt.Sprintf("orders/%d.json", o.ID)); err != nil {
+			return err
+		}
+		fmt.Fprintln(c.out, "order deleted, ID:", o.ID)
+	}
+	return nil
+}
+
+func (c *CreateCmd) Run() error {
+	if c.Unique {
+		orders, err := c.client.Order.List(listOpts(c.Order.Name))
+		if err != nil {
+			return err
+		}
+		if len(orders) != 0 {
+			return fmt.Errorf("order with name %q already exists", c.Order.Name)
+		}
+	}
+	order, err := c.client.Order.Create(*c.Order)
 	if err != nil {
 		return err
 	}
 	fmt.Fprintln(c.out, "order created, ID:", order.ID)
 	return nil
+}
+
+func (c *UpdateCmd) Run() error {
+	orders, err := c.client.Order.List(listOpts(c.Order.Name))
+	if err != nil {
+		return err
+	}
+	if len(orders) == 0 {
+		return fmt.Errorf("order with name %q does not exist", c.Order.Name)
+	}
+	if len(orders) > 1 {
+		return fmt.Errorf("more than one order with name %q", c.Order.Name)
+	}
+	order := orders[0]
+	if _, err = c.client.Order.Update(order); err != nil {
+		return err
+	}
+	fmt.Fprintln(c.out, "order updated, ID:", order.ID)
+	return nil
+}
+
+func (c *MergeCmd) Run() error {
+	orders, err := c.client.Order.List(listOpts(c.Order.Name))
+	if err != nil {
+		return err
+	}
+	if len(orders) > 1 {
+		return fmt.Errorf("expected at most one order with name %q, found %d'", c.Order.Name, len(orders))
+	}
+	if len(orders) == 0 {
+		order, err := c.client.Order.Create(*c.Order)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(c.out, "order merged (created), ID:", order.ID)
+		return nil
+	}
+	order, err := c.client.Order.Update(orders[0])
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.out, "order merged (updated), ID:", order.ID)
+	return nil
+}
+
+func listOpts(name string) goshopify.OrderListOptions {
+	return goshopify.OrderListOptions{Order: name}
 }
 
 var JSONFileMapper = kong.MapperFunc(decodeJSONFile)

--- a/main_test.go
+++ b/main_test.go
@@ -2,38 +2,98 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"testing"
 
-	"github.com/alecthomas/kong"
+	goshopify "github.com/bold-commerce/go-shopify/v3"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRun(t *testing.T) {
 	got := &bytes.Buffer{}
-	args := []string{"--input", "testdata/order1.json"}
-	cfg := testConfig(t, args, got)
-	err := cfg.Run()
+
+	cfg := testConfig(t, got)
+	order := testOrder(t, "testdata/order.json")
+	deleteCmd := DeleteCmd{Config: *cfg, Order: order}
+	require.NoError(t, deleteCmd.Run())
+
+	got.Reset()
+	createCmd := CreateCmd{Config: *cfg, Order: order}
+	require.NoError(t, createCmd.Run())
+	want := "order created, ID: "
+	gotStr := got.String()
+	require.Equal(t, want, gotStr[:len(want)])
+	id := gotStr[len(want) : len(gotStr)-1]
+
+	got.Reset()
+	listCmd := ListCmd{Config: *cfg, Order: order}
+	require.NoError(t, listCmd.Run())
+	want = "number of orders: 1\n"
+	want += fmt.Sprintf("id: %s name: order 1 email: jay@example.com\n", id)
+	require.Equal(t, want, got.String())
+
+	got.Reset()
+	intID, err := strconv.ParseInt(id, 10, 64)
 	require.NoError(t, err)
-	want := "order created, ID:"
+	getCmd := GetCmd{Config: *cfg, ID: intID}
+	require.NoError(t, getCmd.Run())
+
+	got.Reset()
+	mergeCmd := MergeCmd{Config: *cfg, Order: order}
+	require.NoError(t, mergeCmd.Run())
+	want = "order merged (updated), ID: " + id + "\n"
+	require.Equal(t, want, got.String())
+
+	got.Reset()
+	updateCmd := UpdateCmd{Config: *cfg, Order: order}
+	require.NoError(t, updateCmd.Run())
+	want = "order updated, ID: " + id + "\n"
+	require.Equal(t, want, got.String())
+
+	require.NoError(t, createCmd.Run())
+	createCmd.Unique = true
+	require.Error(t, createCmd.Run())
+	deleteCmd.Unique = true
+	require.Error(t, deleteCmd.Run())
+	mergeCmd.Unique = true
+	require.Error(t, mergeCmd.Run())
+
+	got.Reset()
+	deleteCmd = DeleteCmd{Config: *cfg, Order: order}
+	require.NoError(t, deleteCmd.Run())
+	want = "number of orders to delete: 2"
 	require.Equal(t, want, got.String()[:len(want)])
 }
 
-func testConfig(t *testing.T, args []string, out io.Writer) *Config {
+func testConfig(t *testing.T, out io.Writer) *Config {
 	t.Helper()
-	options := append([]kong.Option{kong.Exit(testExit(t))}, kongOpts...)
-	cfg := &Config{}
-	parser, err := kong.New(cfg, options...)
-	require.NoError(t, err)
-	_, err = parser.Parse(args)
-	require.NoError(t, err)
-	cfg.out = out
-	return cfg
+	store := getenv(t, "SHOPIFY_STORE")
+	token := getenv(t, "SHOPIFY_TOKEN")
+	client := goshopify.NewClient(goshopify.App{}, store, token)
+	return &Config{
+		out:    out,
+		client: client,
+	}
 }
 
-func testExit(t *testing.T) func(int) {
-	return func(int) {
-		t.Helper()
-		t.Fatalf("unexpected exit()")
+func getenv(t *testing.T, key string) string {
+	t.Helper()
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		t.Fatalf("cannot find %q in environment", key)
 	}
+	return val
+}
+
+func testOrder(t *testing.T, fname string) *goshopify.Order {
+	f, err := os.Open(fname)
+	require.NoError(t, err)
+	defer f.Close()
+	o := &goshopify.Order{}
+	require.NoError(t, json.NewDecoder(f).Decode(o))
+	return o
 }

--- a/testdata/order.json
+++ b/testdata/order.json
@@ -1,4 +1,5 @@
 {
+    "name" : "order 1",
     "email": "jay@example.com",
     "fulfillment_status": "unfulfilled",
     "line_items":


### PR DESCRIPTION
Implement crud, merge and list commands for single order input as JSON. 
Reuse most of the existing go-shopify order service for this.

Make go install install to repo directory so that there can be a
separate globally installed orderer CLI.